### PR TITLE
Enable outputting only the <testsuite>; not <testsuites> root tag.

### DIFF
--- a/cmd/tap2junit/main.go
+++ b/cmd/tap2junit/main.go
@@ -17,9 +17,10 @@ import (
 var (
 	testName        = flag.String("test_name", "unnamed_test", "Sets the test name to use")
 	reorderDuration = flag.Bool("reorder_duration", false, "If set, will reorder durations to work around https://github.com/bats-core/bats-core/issues/187")
+	singleSuite     = flag.Bool("single_suite", false, "If set, will output only the <testsuite> as top-level tag; not <testsuites>")
 )
 
-func run(r io.Reader, w io.Writer, name string, reorderDuration bool) error {
+func run(r io.Reader, w io.Writer, name string, reorderDuration, singleSuite bool) error {
 	t, err := tap.Read(r, name, reorderDuration)
 	if err != nil {
 		return fmt.Errorf("while reading TAP: %v", err)
@@ -28,7 +29,7 @@ func run(r io.Reader, w io.Writer, name string, reorderDuration bool) error {
 	if err != nil {
 		return fmt.Errorf("while converting to jUnit: %v", err)
 	}
-	if err := junit.Write(j, w); err != nil {
+	if err := junit.Write(j, w, singleSuite); err != nil {
 		return fmt.Errorf("while writing jUnit: %v", err)
 	}
 	return nil
@@ -39,7 +40,7 @@ func init() {
 }
 
 func main() {
-	if err := run(os.Stdin, os.Stdout, *testName, *reorderDuration); err != nil {
+	if err := run(os.Stdin, os.Stdout, *testName, *reorderDuration, *singleSuite); err != nil {
 		glog.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -61,9 +61,17 @@ type Failure struct {
 }
 
 // Write writes out the test suites information into the supplied writer.
-func Write(suites Testsuites, w io.Writer) error {
+func Write(suites Testsuites, w io.Writer, singleSuite bool) error {
 	e := xml.NewEncoder(w)
 	e.Indent("   ", "   ")
-	fmt.Fprintf(w, xml.Header)
+	if _, err := fmt.Fprintf(w, xml.Header); err != nil {
+		return err
+	}
+	if singleSuite {
+		if lenSuites := len(suites.Suites); lenSuites != 1 {
+			return fmt.Errorf("cannot write a singleSuite unless there is exactly one suite (%d)", lenSuites)
+		}
+		return e.Encode(suites.Suites[0])
+	}
 	return e.Encode(suites)
 }

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestOutput(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    Testsuites
-		expected string
+		name        string
+		input       Testsuites
+		singleSuite bool
+		expected    string
 	}{
 		{
 			name: "Example from https://www.ibm.com/support/knowledgecenter/en/SSUFAU_1.0.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html",
@@ -63,11 +64,59 @@ Line: 2
       </testsuite>
    </testsuites>`,
 		},
+		{
+			name: "Example from https://www.ibm.com/support/knowledgecenter/en/SSUFAU_1.0.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html",
+			input: Testsuites{
+				ID:          "20140612_170519",
+				Name:        "New_configuration (14/06/12 17:05:19)",
+				NumTests:    225,
+				NumFailures: 1262,
+				Time:        DurationSec{time.Millisecond},
+				Suites: []Suite{
+					{
+						ID:          "codereview.cobol.analysisProvider",
+						Name:        "COBOL Code Review",
+						NumTests:    45,
+						NumFailures: 17,
+						Time:        DurationSec{time.Millisecond},
+						Testcases: []Case{
+							{
+								ID:   "codereview.cobol.rules.ProgramIdRule",
+								Name: "Use a program name that matches the source file name",
+								Time: DurationSec{time.Millisecond},
+								Failures: []Failure{
+									{
+										Message: "PROGRAM.cbl:2 Use a program name that matches the source file name",
+										Type:    "WARNING",
+										Text: `WARNING: Use a program name that matches the source file name
+Category: COBOL Code Review – Naming Conventions
+File: /project/PROGRAM.cbl
+Line: 2
+`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			singleSuite: true,
+			expected: `<?xml version="1.0" encoding="UTF-8"?>
+   <testsuite id="codereview.cobol.analysisProvider" name="COBOL Code Review" tests="45" failures="17" time="0.001">
+      <testcase id="codereview.cobol.rules.ProgramIdRule" name="Use a program name that matches the source file name" time="0.001">
+         <failure message="PROGRAM.cbl:2 Use a program name that matches the source file name" type="WARNING"><![CDATA[WARNING: Use a program name that matches the source file name
+Category: COBOL Code Review – Naming Conventions
+File: /project/PROGRAM.cbl
+Line: 2
+]]></failure>
+      </testcase>
+   </testsuite>`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var out strings.Builder
-			if err := Write(test.input, &out); err != nil {
+			if err := Write(test.input, &out, test.singleSuite); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			s := strings.Split(out.String(), "\n")


### PR DESCRIPTION
Surefire and gradle both output a single suite per file and some test collectors such as ant's junitreport require that; therefore, add a flag to output only the single suite.