### PR TITLE
Remove log line.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
+
+FROM golang:1.16.5 as build
+WORKDIR /go/src/github.com/filmil/tap2junit
+COPY . .
+RUN go build ./cmd/tap2junit
+RUN chmod 755 tap2junit
+
 FROM gcr.io/distroless/base
 LABEL maintainer="filmil@gmail.com"
-COPY tap2junit /
+COPY --from=build /go/src/github.com/filmil/tap2junit/tap2junit /
 ENTRYPOINT ["/tap2junit"]

--- a/pkg/tap/tap.go
+++ b/pkg/tap/tap.go
@@ -242,7 +242,6 @@ func Read(i io.Reader, opt ReadOpt) (Case, error) {
 				ps, len(r.Results), r.Results, fixup, v, ps.lt,
 			)
 			r.Results[ps.lt+fixup-1].Raw = joinNonempty(r.Results[ps.lt+fixup-1].Raw, v[0])
-			glog.Infof("results: %+v", r.Results)
 			continue
 		}
 

--- a/pkg/tap/tap.go
+++ b/pkg/tap/tap.go
@@ -147,7 +147,7 @@ func Read(i io.Reader, opt ReadOpt) (Case, error) {
 
 		// Range is the range of the tests to run.
 		// "1..42"
-		var Range = regexp.MustCompile(`(\d+)\.\.(\d+)`)
+		var Range = regexp.MustCompile(`^(\d+)\.\.(\d+)$`)
 		if v := Range.FindStringSubmatch(t); v != nil {
 			glog.V(2).Infof("range: %v", spew.Sdump(v))
 			f := toInt(v[1])


### PR DESCRIPTION
This log line was causing logfiles hundreds of MB large since it would
output n^2 lines from an annotated test case.